### PR TITLE
SQ3 ScumSoft  announce script fixed

### DIFF
--- a/pq2/src/Main.sc
+++ b/pq2/src/Main.sc
@@ -506,7 +506,8 @@
 		(= systemWindow (SysWindow new:))
 		(super init:)
 		;(= debugging FALSE)
-		(= debugging TRUE)	;added to enable debug features
+		;(= debugging TRUE)	;added to enable debug features
+		;"kiss angel death" now toggles debugging
 		(= ego egoObj)
 		(User alterEgo: ego blocks: 0 y: 155)
 		(TheMenuBar init:)
@@ -727,7 +728,8 @@
 		(switch (event type?)
 			(saidEvent
 				(cond 
-					((and (Said 'kiss/angel>') (Said '/death'))
+					;((and (Said 'kiss/angel>') (Said '/death'))
+					((Said 'kiss/death<angel')
 						(event claimed: TRUE)
 						(if (^= debugging TRUE)
 							(curRoom setLocales: DEBUG)
@@ -751,7 +753,7 @@
 					)
 					(
 						(or
-							(Said 'fuck,crap,cunt,cocksucker,leak')	;EO: removed kiss to allow debugging
+							(Said 'kiss,fuck,crap,cunt,cocksucker,leak')
 							(Said '/fuck,crap,cunt,cocksucker,leak')
 							(Said 'eat/crap,and,die')
 						)

--- a/sq3/src/Main.sc
+++ b/sq3/src/Main.sc
@@ -1224,7 +1224,7 @@
 					(= evtX (event x?))
 					(= evtY (event y?))
 					(cond 
-						((== (= evtMod (event modifiers?)) 10)
+						((& (= evtMod (event modifiers?)) 10) ;shift+ALT+click
 							(event claimed: TRUE)
 							((User alterEgo?) setMotion: JumpTo evtX evtY)
 						)

--- a/sq3/src/ScumSoft.sc
+++ b/sq3/src/ScumSoft.sc
@@ -105,7 +105,8 @@
 	
 	(method (doit)
 		(if (and (not scumSoftAlerted) (== 700 (Random 1 1400)))
-			(announce cue:)
+			;(announce cue:)
+			(announce changeState: scumSoftAnnouncement)
 		)
 	)
 	

--- a/sq3/src/ScumSoft.sc
+++ b/sq3/src/ScumSoft.sc
@@ -172,12 +172,13 @@
 	)
 	
 	(method (init)
+		(super init:)
 		(self
 			vaporized: [trashVaporized myID]
 			view: 115
 			ignoreActors: 0
 			setLoop: 4
-			setCel: [trashVaporized (super init:)]
+			setCel: [trashVaporized myID]
 			stopUpd:
 		)
 		(if (and vaporized myID)

--- a/sq3/src/ScumSoft.sc
+++ b/sq3/src/ScumSoft.sc
@@ -106,6 +106,7 @@
 	(method (doit)
 		(if (and (not scumSoftAlerted) (== 700 (Random 1 1400)))
 			;(announce cue:)
+			(if (== scumSoftAnnouncement 0) (++ scumSoftAnnouncement))
 			(announce changeState: scumSoftAnnouncement)
 		)
 	)


### PR DESCRIPTION
In SQ3 version 1.018, Script::cue was changed to check that each script has a client. Since announce script does not, cue: has no effect.