### PR TITLE
QFG4CD: Import.sc: Fix extra closing brace

### DIFF
--- a/qfg4cd/src/Import.sc
+++ b/qfg4cd/src/Import.sc
@@ -654,7 +654,7 @@
 						(newStr cat: curDir)
 						(= curDirSize (curDir size:))
 						(= temp4 (curDir at: (- curDirSize 1)))
-						(if (OneOf temp4 92 58) 0 else (newStr cat: {\\}}))
+						(if (OneOf temp4 92 58) 0 else (newStr cat: {\\}))
 						(newStr cat: saveFileSelText)
 						(heroinfo name: (newStr data?))
 					)


### PR DESCRIPTION
The import script intends to add the backslash character `\` to a string. This character is decompiled into `\\`, because `\` is used to escape special characters. This script uses braces for the string literal: `{\\}`. The decompiled script was incorrectly modified to add an additional closing brace, `{\\}}`.

The syntax highlighting and compiler in SCI Companion is buggy: it doesn't support escaping a backslash character. So for `{\\}`, it treats the closing brace as escaped. (I am working on a fix for [Kawa's fork](https://github.com/Kawa-oneechan/SCICompanion) of SCI Companion.)

My theory is that someone saw SCI Companion's syntax highlighting, which thought the string was unclosed, and added an extra closing brace to "fix" it (and actually break it).

- Original, correct: https://github.com/EricOakford/SCI-Decompilation-Archive/blob/e5e280094ae623c2037055269ab522d5c7cfa50f/qfg4cd/src/Import.sc#L601
- Current, incorrect: https://github.com/EricOakford/SCI-Decompilation-Archive/blob/35cdfd4c531a1b02fa089784d34c34afc9e4f06e/qfg4cd/src/Import.sc#L657